### PR TITLE
feat: Add API test and PHP server config

### DIFF
--- a/.cartero/user_create.cartero
+++ b/.cartero/user_create.cartero
@@ -1,0 +1,18 @@
+version = 1
+url = "http://localhost:8000/api/user/create"
+method = "POST"
+
+[body]
+type = "multipart"
+
+[body.variables]
+email = "test@h.f"
+username = "krmeni"
+displayname = "Krmení šneků"
+password = "šneků"
+
+[headers]
+
+[variables]
+
+[inactive-params]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,53 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch built-in server",
+            "type": "php",
+            "request": "launch",
+            "runtimeArgs": [
+                "-S",
+                "localhost:8000",
+                "-t",
+                "."
+            ],
+            "port": 9003,
+        },
+        {
+            "name": "Launch built-in server and Debug",
+            "type": "php",
+            "request": "launch",
+            "noDebug": false,
+            "runtimeArgs": [
+                "-S",
+                "localhost:8000",
+                "-t",
+                "."
+            ],
+            "cwd": "${workspaceRoot}/.",
+        },
+        {
+            "name": "Launch built-in server and Profile",
+            "type": "php",
+            "request": "launch",
+            "noDebug": true,
+            "runtimeArgs": [
+                "-S",
+                "localhost:8000",
+                "-t",
+                "."
+            ],
+            "cwd": "${workspaceRoot}/.",
+            "profile": true,
+            "openProfile": true
+        },
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch"
+        }
+    ]
+}


### PR DESCRIPTION
- Add new API endpoint test for user creation with POST method and required form data.
- Create launch configuration for PHP server with multiple launch options including debugging, profiling, and Xdebug listening.