### PR TITLE
feat: Add PostgreSQL support to database configuration and connection logic.

### DIFF
--- a/app/Configs/db.ini.example
+++ b/app/Configs/db.ini.example
@@ -6,3 +6,8 @@ password = ""
 
 ; sqlite
 ; dsn = "sqlite:data/db.sqlite"
+
+; postgresql
+; dsn = "pgsql:host=localhost;dbname=lantern"
+; username = "root"
+; password = ""

--- a/index.php
+++ b/index.php
@@ -25,6 +25,7 @@ switch ($base->get("ATH.DATABASE_CONNECTION_TYPE")) {
         break;
     default:
     case "mysql":
+    case "pgsql":
         $base->set('DB', new \DB\SQL(
             $base->get('db.dsn'),
             $base->get('db.username'),


### PR DESCRIPTION
- Add PostgreSQL configuration to the database settings.
- Add 'pgsql' case to the switch statement to support PostgreSQL database connections.

Closes #16 