### PR TITLE
Fix tag endpoint entry count

### DIFF
--- a/app/Controllers/SearchTags.php
+++ b/app/Controllers/SearchTags.php
@@ -39,17 +39,23 @@ class SearchTags
             return Responsivity::respond('Unauthorized', Responsivity::HTTP_Unauthorized);
 
         $model = new \Models\Tag();
-        $entry = $model->findone(['name=?', $base->get('PARAMS.tag')]);
-        if (!$entry) {
+        $tag = $model->findone(['name=?', $base->get('PARAMS.tag')]);
+        if (!$tag) {
             return Responsivity::respond('Tag not found', Responsivity::HTTP_Not_Found);
         }
-        unset($model);
         $model = new \Models\Entry();
-        $entries = $model->afind(['tags=?', $base->get('PARAMS.tag')]);
+        $tagID = $tag->_id;
+        $entryCount = $model->count([
+            'tags = ? OR tags LIKE ? OR tags LIKE ? OR tags LIKE ?',
+            '[' . $tagID . ']',
+            '[' . $tagID . ',%',
+            '%,' . $tagID . ',%',
+            '%,' . $tagID . ']'
+        ], null, 0);
 
         $cast = [
             'name' => $base->get('PARAMS.tag'),
-            'count' => $entries ? count($entries) : 0
+            'count' => $entryCount
         ];
 
         Responsivity::respond($cast);


### PR DESCRIPTION
Fixes #57

## Summary
- resolve the requested tag first and use its id when counting tagged entries
- count entries through the `Entry::tags` relation so `/api/search/tag/{tag}` reports the actual number of matching entries

## Tests
- `php -l app/Controllers/SearchTags.php`
- `git diff --check`
- SQLite smoke test creating two entries with different tags and verifying the target tag count is `1`